### PR TITLE
Support the MaxMind GeoLite2 ASN database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+virtualenv/
 
 # Spyder project settings
 .spyderproject

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3
+- Use the GeoIP Lite ASN DB by default.
+- Require geoip2 >= 2.5.0 for GeoIP Lite ASN support.
+
 ## 0.2
 - Added `geoip` action and action alias.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.3
-- Use the GeoIP Lite ASN DB by default.
+- Add support for the GeoIP Lite ASN DB.
 - Require geoip2 >= 2.5.0 for GeoIP Lite ASN support.
 
 ## 0.2

--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ city_db: "/path/to/GeoLite2-City.mmdb"
 To use the `geoip` action you need to download one at least one of the
 following databases:
 
-- The (City geolite2)[http://dev.maxmind.com/geoip/geoip2/geolite2/] (licensed under CC BY-SA 4.0) database.
+- The (GeoLite2 City)[http://dev.maxmind.com/geoip/geoip2/geolite2/] (licensed under CC BY-SA 4.0) database.
 - The paid (City)[https://www.maxmind.com/en/geoip2-city] database.
 - The paid (ISP)[https://www.maxmind.com/en/geoip2-isp-database] database.
+- The (GeoLite2 ASN)[http://dev.maxmind.com/geoip/geoip2/geolite2/] (licensed under CC BY-SA 4.0) database.
 
 And place into `/opt/geoip2/` or if you install elsewhere you'll need
 to create a config file with the paths.
 
-Currently only the _City_ and _ISP_ databases currently supported.
+Currently only the _City_, _ASN_ or_ISP_ databases supported.

--- a/actions/geoip.py
+++ b/actions/geoip.py
@@ -101,7 +101,7 @@ class GeoIpAction(Action):
                     details['org'] = {'name': "Org",
                                       'value': response.organization}
                 elif reader_asn:
-                    response = reader.asn(ip_address)
+                    response = reader_asn.asn(ip_address)
 
                     details['as_num'] = {'name': "AS Number",
                                          'value': response.autonomous_system_number} # NOQA

--- a/actions/geoip.py
+++ b/actions/geoip.py
@@ -31,11 +31,16 @@ class GeoIpAction(Action):
             reader_isp = None
 
         try:
+            reader_asn = geoip2.database.Reader(self.config['asn_db'])
+        except IOError:
+            reader_asn = None
+
+        try:
             reader_city = geoip2.database.Reader(self.config['city_db'])
         except IOError:
             reader_city = None
 
-        return (reader_isp, reader_city)
+        return (reader_isp, reader_asn, reader_city)
 
     def run(self, ip_addresses):
         """
@@ -55,9 +60,9 @@ class GeoIpAction(Action):
         results = {"geoip": {}}
         status = False
 
-        (reader_isp, reader_city) = self._get_databases()
+        (reader_isp, reader_asn, reader_city) = self._get_databases()
 
-        if reader_city is None and reader_isp is None:
+        if reader_city is None and reader_isp is None and reader_asn is None:
             results['error'] = "No GeoIP2 databases"
             return (status, results)
         else:
@@ -95,6 +100,13 @@ class GeoIpAction(Action):
                                       'value': response.isp}
                     details['org'] = {'name': "Org",
                                       'value': response.organization}
+                elif reader_asn:
+                    response = reader.asn(ip_address)
+
+                    details['as_num'] = {'name': "AS Number",
+                                         'value': response.autonomous_system_number} # NOQA
+                    details['as_org'] = {'name': "AS Org",
+                                         'value': response.autonomous_system_organization}  # NOQA
 
                 if reader_city:
                     response = reader_city.city(ip_address)

--- a/actions/geoip.py
+++ b/actions/geoip.py
@@ -104,7 +104,7 @@ class GeoIpAction(Action):
                     response = reader_asn.asn(ip_address)
 
                     details['as_num'] = {'name': "AS Number",
-                                         'value': response.autonomous_system_number} # NOQA
+                                         'value': response.autonomous_system_number}  # NOQA
                     details['as_org'] = {'name': "AS Org",
                                          'value': response.autonomous_system_organization}  # NOQA
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -2,7 +2,7 @@ isp_db:
   description: "Path to ISP GeoIP2 database"
   type: "string"
   required: true
-  default: "/opt/geoip2/GeoIP2-ISP.mmdb"
+  default: "/opt/geoip2/GeoLite2-ASN.mmdb"
 city_db:
   description: "Path to City GeoIP2 database"
   type: "string"

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -2,6 +2,11 @@ isp_db:
   description: "Path to ISP GeoIP2 database"
   type: "string"
   required: true
+  default: "/opt/geoip2/GeoIP2-ISP.mmdb"
+asn_db:
+  description: "Path to GeoLite2-ASN database"
+  type: "string"
+  required: true
   default: "/opt/geoip2/GeoLite2-ASN.mmdb"
 city_db:
   description: "Path to City GeoIP2 database"

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - ipv4
     - ipv6
     - geoip
-version: 0.2.0
+version: 0.3.0
 author: Jon Middleton
 email: jon.middleton@pulsant.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ipaddress>=1.0.16
-geoip2
+geoip2>=2.5.0

--- a/tests/fixtures/full.yaml
+++ b/tests/fixtures/full.yaml
@@ -1,3 +1,4 @@
 ---
 isp_db: "/opt/geoip2/GeoIP2-ISP.mmdb"
+asn_db: "/opt/geoip2/GeoLite2-ASN.mmdb"
 city_db: "/opt/geoip2/GeoLite2-City.mmdb"

--- a/tests/test_action_geoip.py
+++ b/tests/test_action_geoip.py
@@ -62,7 +62,7 @@ class FakeISPReader(object):
 
 
 class FakeASNReader(object):
-    def isp(self, ip_address):
+    def asn(self, ip_address):
         return FakeASN()
 
     def close(self):


### PR DESCRIPTION
Adds support for the free MaxMind GeoLite2 ASN database (Fixes: #2).

Example output:

```
@hubot geoip 8.8.8.8
The GeoIP details you requested:
*8.8.8.8:*
 _City:_ Mountain View
 _Country:_ United States
 _Lon:_ -122.0838
 _Google Map:_ https://maps.google.com/maps/place//@37.386,-122.0838,10z
 _Lat:_ 37.386
 _AS Org:_ Google Inc.
 _AS Number:_ 15169
```