### PR TITLE
Betterize tests and update resolve action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0
+
+- Minor fixups and improvements
+- Pin geoip2 and maxminddb versions to ensure Python 2.7 compatibility
+- Update `resolve` action to use `getaddrinfo` instead of `gethostbyname_ex`
+
 ## 0.5.0
 - Added `contains` action
 - Added `fping` action

--- a/actions/resolve.py
+++ b/actions/resolve.py
@@ -29,7 +29,10 @@ class Resolve(Action):
         if reverse:
             response = [socket.gethostbyaddr(request)[0]]
         else:
-            response = socket.gethostbyname_ex(request)[2]
+            response = [
+                record[4][0]
+                for record in socket.getaddrinfo(request, None, socket.AF_INET, socket.SOCK_DGRAM)
+            ]
 
         self.logger.debug("Resolved %s -> %s", request, response)
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
     - ipv6
     - geoip
     - ping
-version: 0.5.0
+version: 0.6.0
 python_versions:
     - "2"
     - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ipaddress>=1.0.16
-geoip2>=2.5.0
+geoip2>=2.5.0,<4.0.0  # 4.0.0+ is Python 3 only

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ipaddress>=1.0.16
 geoip2>=2.5.0,<4.0.0  # 4.0.0+ is Python 3 only
+maxminddb<2.0  # 2.0+ is Python 3.6 only

--- a/tests/test_action_fping.py
+++ b/tests/test_action_fping.py
@@ -33,6 +33,4 @@ class FPingTestCase(NetworkingUtilsBaseActionTestCase):
         )
         result = action.run("127.0.0.1", interval=1, count=3)
 
-        self.assertTrue(
-            result["packets"]["transmitted"] == result["packets"]["received"]
-        )
+        self.assertEquals(result["packets"]["transmitted"], result["packets"]["received"])

--- a/tests/test_action_resolve.py
+++ b/tests/test_action_resolve.py
@@ -28,5 +28,5 @@ class ResolveTestCase(NetworkingUtilsBaseActionTestCase):
     def test_resolve_localhost(self):
         action = self.get_action_instance()
 
-        self.assertTrue("localhost" in action.run("127.0.0.1", reverse=True))
-        self.assertTrue("127.0.0.1" in action.run("localhost"))
+        self.assertIn("localhost", action.run("127.0.0.1", reverse=True))
+        self.assertIn("127.0.0.1", action.run("localhost"))

--- a/tests/test_action_traceroute_mtr.py
+++ b/tests/test_action_traceroute_mtr.py
@@ -57,4 +57,4 @@ class TracerouteMTRTestCase(NetworkingUtilsBaseActionTestCase):
 
         result = action.run("127.0.0.1")
 
-        self.assertTrue(len(result["report"]["hubs"]) > 0)
+        self.assertGreater(len(result["report"]["hubs"]), 0)

--- a/tests/test_action_traceroute_mtr.py
+++ b/tests/test_action_traceroute_mtr.py
@@ -28,31 +28,31 @@ class TracerouteMTRTestCase(NetworkingUtilsBaseActionTestCase):
         action = self.get_action_instance()
 
         mock.return_value = b"""
-    {
-    "report": {
-      "mtr": {
-        "src": "test",
-        "dst": "127.0.0.1",
-        "tos": "0x0",
-        "psize": "64",
-        "bitpattern": "0x00",
-        "tests": "10"
-      },
-      "hubs": [
-        {
-          "count": "1",
-          "host": "localhost",
-          "Loss%": 0,
-          "Snt": 10,
-          "Last": 0.07,
-          "Avg": 0.07,
-          "Best": 0.07,
-          "Wrst": 0.1,
-          "StDev": 0.01
-        }
-      ]
-    }
+{
+  "report": {
+    "mtr": {
+      "src": "test",
+      "dst": "127.0.0.1",
+      "tos": "0x0",
+      "psize": "64",
+      "bitpattern": "0x00",
+      "tests": "10"
+    },
+    "hubs": [
+      {
+        "count": "1",
+        "host": "localhost",
+        "Loss%": 0,
+        "Snt": 10,
+        "Last": 0.07,
+        "Avg": 0.07,
+        "Best": 0.07,
+        "Wrst": 0.1,
+        "StDev": 0.01
+      }
+    ]
   }
+}
     """
 
         result = action.run("127.0.0.1")


### PR DESCRIPTION
The `resolve` action was using `socket.gethostbyname_ex`, which [does not support IPv6 resolution](https://docs.python.org/2/library/socket.html#socket.gethostbyname_ex).

This PR updates the `resolve` action to use [`socket.getaddrinfo`](https://docs.python.org/2/library/socket.html#socket.getaddrinfo), pins dependencies to Python 2.7 compatible versions, and improves the test assertions a bit.

I bumped the pack version to `0.6.0`, since the changes made to the `resolve` action were slightly more than just fixing a bug.