### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @jjm @StackStorm-Exchange/tsc
+.circleci/** @StackStorm-Exchange/tsc


### PR DESCRIPTION
Add a `CODEOWNERS` file to automate review assignment.

As mentioned on #18, we count mostly on manual assignment of CODEOWNERS, here's a example file as mentioned by @armab [here](https://github.com/StackStorm-Exchange/stackstorm-networking_utils/pull/18#issuecomment-662996339).