### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+* Updated test files to work with latest CI updates
+
 ## 1.2.0
 
 * Add IP calculator action

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,7 +9,7 @@ keywords:
     - ipv6
     - geoip
     - ping
-version: 1.2.0
+version: 1.2.1
 python_versions:
     - "3"
 author: Jon Middleton

--- a/tests/networking_utils_base_test_case.py
+++ b/tests/networking_utils_base_test_case.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 
 import yaml
-import unittest2
+import unittest
 
 from st2tests.base import BaseActionTestCase
 
@@ -38,7 +38,7 @@ class NetworkingUtilsBaseActionTestCase(BaseActionTestCase):
     def full_config(self):
         return self._full_config
 
-    @unittest2.skip("Pack does not currently have any config")
+    @unittest.skip("Pack does not currently have any config")
     def test_run_no_config(self):
         self.assertRaises(ValueError, self.action_cls, self.blank_config)
 

--- a/tests/test_action_fping.py
+++ b/tests/test_action_fping.py
@@ -31,4 +31,4 @@ class FPingTestCase(NetworkingUtilsBaseActionTestCase):
         mock.return_value = b"8.8.8.8 : xmt/rcv/%loss = 10/10/0%, min/avg/max = 4.78/4.85/4.91\n"
         result = action.run("127.0.0.1", interval=1, count=3)
 
-        self.assertEquals(result["packets"]["transmitted"], result["packets"]["received"])
+        self.assertEqual(result["packets"]["transmitted"], result["packets"]["received"])


### PR DESCRIPTION
Fixed test files to work with latest CI updates
- unittest2 doesn't work with python 3.10 because it requires a `MutableMapping` class that moved from `collections` to `collections.abc`. unittest also contains the function we need so we can just use that instead
https://stackoverflow.com/questions/70870041/cannot-import-name-mutablemapping-from-collections

- `assertEquals` has been deprecated since python 2.7 and replaced with `assertEqual`
https://pydoc-zh.readthedocs.io/en/latest/library/unittest.html#deprecated-aliases
